### PR TITLE
typo: fix `requires-python` field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = ["hatchling<1.22"]
 
 [project]
-requires_python = "3.10"
+requires-python = "3.10"
 name = "useful-coderunner"
 version = "1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "hatchling.build"
 requires = ["hatchling<1.22"]
 
 [project]
-requires-python = "3.10"
+requires-python = ">=3.10"
 name = "useful-coderunner"
 version = "1.0"
 


### PR DESCRIPTION
it should be `requires-python` not `requires_python` and it should be `3.10.*` or `>=3.10`